### PR TITLE
Static id method on migrations to save memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Loggers take care of registering the migrations that have been run already. This
 
 ## Migration structure
 
-All of the migrations are required to follow a specific format, being enforced by the `CoenJacobs\Migrator\Contracts\Migration.php` interface. This interface enforces your migration class to contain at least two methods: `up()` and `down()`. These two methods are used to run and rollback your migration.
+All of the migrations are required to follow a specific format, being enforced by the `CoenJacobs\Migrator\Contracts\Migration.php` interface. This interface will force you to provide a static `id()` method, which will need to provide the unique identifier of the migration. The interface also enforces your migration class to contain the following two methods: `up()` and `down()`. These two methods are used to run and rollback your migration.
 
 There is a helper `BaseMigration` available, to help with setting up the right variables for the migration, such as the Worker.
 
@@ -33,13 +33,13 @@ A basic migration example looks like this:
 ```php
 <?php
 
-use CoenJacobs\Migrator\Migrations\BaseMigration;
-
 namespace YourPlugin\Migrations;
+
+use CoenJacobs\Migrator\Migrations\BaseMigration;
 
 class CreateTestTable extends BaseMigration
 {
-    public function getId()
+    public static function id()
     {
         return 'yourplugin-1-test-table';
     }
@@ -80,12 +80,12 @@ $worker = new WpdbWorker();
 $migrator = new Handler($worker, new DatabaseLogger());
 ```
 
-After that, the Handler is ready to accept new migrations to be added, before they can be run. Each Migration needs to be provided with a Worker class, again implementing the `CoenJacobs\Migrator\Contracts\Worker` interface, which is responsible for running the queries inside your Migration. You can pass a different Worker class to your Migration, than the one you have passed to the Handler, but you can also use the same:
+After that, the Handler is ready to accept new migrations to be added, before they can be run. You pass the class as a string of the class name, where the class itself again implements the `CoenJacobs\Migrator\Contracts\Migration` interface:
 
 ```php
 use YourPlugin\Migrations\CreateTestTable
 
-$migrator->add('yourplugin', new CreateTestTable($worker));
+$migrator->add('yourplugin', CreateTestTable::class);
 ```
 
 The first parameter in the `$migration->add()` method should be a unique identifier for your plugin. The handler runs the migrations on a per plugin basis, using this unique identifier as the key to call the right migrations to be run. 

--- a/src/Contracts/Migration.php
+++ b/src/Contracts/Migration.php
@@ -4,7 +4,7 @@ namespace CoenJacobs\Migrator\Contracts;
 
 interface Migration
 {
-    public function getId();
+    public static function id();
     public function up();
     public function down();
 }

--- a/src/Loggers/DatabaseLogger.php
+++ b/src/Loggers/DatabaseLogger.php
@@ -8,7 +8,7 @@ class DatabaseLogger extends BaseLogger
 {
     public function add($plugin_key, Migration $migration, $batch)
     {
-        $id = $migration->getId();
+        $id = $migration->id();
         $tableName = $this->worker->getPrefix() . 'migrator_migrations';
 
         $batch = intval($batch);
@@ -20,7 +20,7 @@ class DatabaseLogger extends BaseLogger
 
     public function remove($plugin_key, Migration $migration)
     {
-        $id = $migration->getId();
+        $id = $migration->id();
         $tableName = $this->worker->getPrefix() . 'migrator_migrations';
         $query = "DELETE FROM $tableName (migration, plugin_key)
                   VALUES ('$id', '$plugin_key')";

--- a/src/Migrations/CreateMigrationsTable.php
+++ b/src/Migrations/CreateMigrationsTable.php
@@ -4,7 +4,7 @@ namespace CoenJacobs\Migrator\Migrations;
 
 class CreateMigrationsTable extends BaseMigration
 {
-    public function getId()
+    public static function id()
     {
         return 'migrator-1-migrations-table';
     }


### PR DESCRIPTION
This is to ensure that only the migrations that are actually being run, are being made an instance of the class that is passed. This saves memory and increases performance. Props @dannyvankooten. 🎉 