### PR TITLE
Logger table is only being setup if DatabaseLogger is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Worker classes are the classes responsible for actually performing the queries y
 
 ## Loggers
 
-Loggers take care of registering the migrations that have been run already. This is to ensure that no migrations are being run more than once. By default, there is a database based Logger available, in the `CoenJacobs\Migrator\Loggers\DatabaseLogger` class. This class actually uses the aforementioned `$wpdb` based Worker, in order to log the migration data into a specific database table. You can provide your own implementation of the Logger class, as long as they implement the `CoenJacobs\Migrator\Contracts\Logger` interface.
+Loggers take care of registering the migrations that have been run already. This is to ensure that no migrations are being run more than once. By default, there is a database based Logger available, in the `CoenJacobs\Migrator\Loggers\DatabaseLogger` class. This class actually uses the aforementioned `$wpdb` based Worker, in order to log the migration data into a specific database table. This database table is being created, using the table name you've provided as the first contructor argument.
+
+You can provide your own implementation of the Logger class, as long as they implement the `CoenJacobs\Migrator\Contracts\Logger` interface.
 
 ## Migration structure
 
@@ -77,7 +79,8 @@ use CoenJacobs\Migrator\Loggers\DatabaseLogger;
 use CoenJacobs\Migrator\Workers\WpdbWorker;
 
 $worker = new WpdbWorker();
-$migrator = new Handler($worker, new DatabaseLogger());
+$logger = new DatabaseLogger('migrations_table_name');
+$handler = new Handler($worker, $logger);
 ```
 
 After that, the Handler is ready to accept new migrations to be added, before they can be run. You pass the class as a string of the class name, where the class itself again implements the `CoenJacobs\Migrator\Contracts\Migration` interface:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,7 @@
 	>
 	<testsuites>
 		<testsuite name="unit">
-			<directory suffix=".php">./tests/unit/</directory>
+			<directory suffix=".php">./tests/Unit/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
 	backupGlobals="false"
+	bootstrap="vendor/autoload.php"
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"

--- a/src/Exceptions/ReservedNameException.php
+++ b/src/Exceptions/ReservedNameException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace CoenJacobs\Migrator\Exceptions;
-
-use Exception;
-
-class ReservedNameException extends Exception
-{
-}

--- a/src/Loggers/DatabaseLogger.php
+++ b/src/Loggers/DatabaseLogger.php
@@ -24,6 +24,8 @@ class DatabaseLogger extends BaseLogger
             $migration = new CreateMigrationsTable($this->worker);
             $migration->setTableName($this->tableName);
             $migration->up();
+
+            $this->setup = true;
         }
     }
 

--- a/src/Loggers/DatabaseLogger.php
+++ b/src/Loggers/DatabaseLogger.php
@@ -29,29 +29,6 @@ class DatabaseLogger extends BaseLogger
         }
     }
 
-    public function isTableSetup()
-    {
-        if ($this->setup === true) {
-            return true;
-        }
-
-        $databaseName = $this->worker->getDatabaseName();
-
-        // Check if table exists before we try to query it
-        $query = "SELECT count(*)
-                  FROM information_schema.TABLES
-                  WHERE (TABLE_SCHEMA = '$databaseName') AND (TABLE_NAME = '$this->tableName')";
-
-        $result = $this->worker->getResults($query);
-
-        if (empty($result) || $result[0]->{"count(*)"} == 0) {
-            return false;
-        }
-
-        $this->setup = true;
-        return true;
-    }
-
     public function add($plugin_key, Migration $migration, $batch)
     {
         $this->init();
@@ -87,6 +64,7 @@ class DatabaseLogger extends BaseLogger
         foreach ($results as $result) {
             $migrations[] = $result->migration;
         }
+
         return $migrations;
     }
 
@@ -102,5 +80,28 @@ class DatabaseLogger extends BaseLogger
         }
 
         return array_pop($results)->batch;
+    }
+
+    protected function isTableSetup()
+    {
+        if ($this->setup === true) {
+            return true;
+        }
+
+        $databaseName = $this->worker->getDatabaseName();
+
+        // Check if table exists before we try to query it
+        $query = "SELECT count(*)
+                  FROM information_schema.TABLES
+                  WHERE (TABLE_SCHEMA = '$databaseName') AND (TABLE_NAME = '$this->tableName')";
+
+        $result = $this->worker->getResults($query);
+
+        if (empty($result) || $result[0]->{"count(*)"} == 0) {
+            return false;
+        }
+
+        $this->setup = true;
+        return true;
     }
 }

--- a/src/Loggers/DatabaseLogger.php
+++ b/src/Loggers/DatabaseLogger.php
@@ -10,6 +10,9 @@ class DatabaseLogger extends BaseLogger
     /** @var string */
     protected $tableName;
 
+    /** @var bool */
+    protected $setup = false;
+
     public function __construct($tableName)
     {
         $this->tableName = $tableName;
@@ -26,6 +29,10 @@ class DatabaseLogger extends BaseLogger
 
     public function isTableSetup()
     {
+        if ($this->setup === true) {
+            return true;
+        }
+
         $databaseName = $this->worker->getDatabaseName();
 
         // Check if table exists before we try to query it
@@ -39,6 +46,7 @@ class DatabaseLogger extends BaseLogger
             return false;
         }
 
+        $this->setup = true;
         return true;
     }
 

--- a/src/Migrations/CreateMigrationsTable.php
+++ b/src/Migrations/CreateMigrationsTable.php
@@ -4,16 +4,22 @@ namespace CoenJacobs\Migrator\Migrations;
 
 class CreateMigrationsTable extends BaseMigration
 {
+    /** @var string */
+    protected $tableName;
+
     public static function id()
     {
         return 'migrator-1-migrations-table';
     }
 
+    public function setTableName($tableName)
+    {
+        $this->tableName = $tableName;
+    }
+
     public function up()
     {
-        $tableName = $this->worker->getPrefix() . 'migrator_migrations';
-
-        $query = "CREATE TABLE $tableName (
+        $query = "CREATE TABLE $this->tableName (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
             migration VARCHAR(255) NOT NULL,
             plugin_key VARCHAR(255) NOT NULL,
@@ -24,9 +30,7 @@ class CreateMigrationsTable extends BaseMigration
 
     public function down()
     {
-        $tableName = $this->worker->getPrefix() . 'migrator_migrations';
-
-        $query = "DROP TABLE $tableName";
+        $query = "DROP TABLE $this->tableName";
         $this->worker->query($query);
     }
 }

--- a/tests/Unit/HandlerTest.php
+++ b/tests/Unit/HandlerTest.php
@@ -7,9 +7,9 @@ use CoenJacobs\Migrator\Handler;
 use CoenJacobs\Migrator\Loggers\BaseLogger;
 use CoenJacobs\Migrator\Migrations\BaseMigration;
 use CoenJacobs\Migrator\Workers\BaseWorker;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class HandlerTest extends PHPUnit_Framework_TestCase
+class HandlerTest extends TestCase
 {
     /** @test */
     public function callsUpOnMigration()

--- a/tests/Unit/HandlerTest.php
+++ b/tests/Unit/HandlerTest.php
@@ -2,70 +2,81 @@
 
 namespace CoenJacobs\MigratorTests\Unit;
 
+use CoenJacobs\Migrator\Contracts\Migration as MigrationContract;
 use CoenJacobs\Migrator\Handler;
-use CoenJacobs\Migrator\Contracts\Logger;
-use CoenJacobs\Migrator\Contracts\Worker;
-use CoenJacobs\Migrator\Contracts\Migration;
+use CoenJacobs\Migrator\Loggers\BaseLogger;
+use CoenJacobs\Migrator\Migrations\BaseMigration;
+use CoenJacobs\Migrator\Workers\BaseWorker;
 use PHPUnit_Framework_TestCase;
 
 class HandlerTest extends PHPUnit_Framework_TestCase
 {
-    private $worker;
-    private $logger;
-    private $downLogger;
-    private $migration;
-
-    public function setUp()
+    /** @test */
+    public function callsUpOnMigration()
     {
-        $this->worker = $this->getMockBuilder(Worker::class)
-            ->getMock();
+        $this->expectExceptionMessage('up method called');
 
-        $this->logger = $this->getMockBuilder(Logger::class)
-            ->getMock();
-        $this->logger->expects($this->any())
-            ->method('getLoggedMigrations')
-            ->will($this->returnValue([]));
-
-        $this->downLogger = $this->getMockBuilder(Logger::class)
-            ->getMock();
-        $this->downLogger->expects($this->any())
-            ->method('getLoggedMigrations')
-            ->will($this->returnValue(['test-migration']));
-
-        $this->migration = $this->getMockBuilder(Migration::class)
-            ->getMock();
-        $this->migration->expects($this->any())
-            ->method('getId')
-            ->will($this->returnValue('test-migration'));
+        $handler = new Handler(new Worker(), new Logger());
+        $handler->add('test-up-migrations', Migration::class);
+        $handler->up('test-up-migrations');
     }
 
     /** @test */
-    public function testHandlerCallsUpOnMigration()
+    public function callsDownOnMigration()
     {
-        $this->migration->expects($this->once())->method('up');
+        $this->expectExceptionMessage('down method called');
 
-        $handler = new Handler($this->worker, $this->logger);
-        $handler->add('test', $this->migration);
-        $handler->up('test');
+        $handler = new Handler(new Worker(), new Logger());
+        $handler->add('test-down-migrations', Migration::class);
+        $handler->down('test-down-migrations');
+    }
+}
+
+class Logger extends BaseLogger
+{
+    public function add($plugin_key, MigrationContract $migration, $batch) { }
+    public function remove($plugin_key, MigrationContract $migration) { }
+
+    public function getLoggedMigrations($plugin_keys)
+    {
+        if (in_array('test-down-migrations', $plugin_keys)) {
+            return ['test-migration'];
+        } else {
+            return [];
+        }
     }
 
-    /** @test */
-    public function testHandlerCallsDownOnMigration()
-    {
-        $this->migration->expects($this->once())->method('down');
+    public function getHighestBatchNumber() { }
+}
 
-        $handler = new Handler($this->worker, $this->downLogger);
-        $handler->add('test', $this->migration);
-        $handler->down('test');
+class Worker extends BaseWorker
+{
+    public function getPrefix() { }
+    public function getDatabaseName() { }
+    public function query($query) { }
+    public function getResults($query) { }
+}
+
+class Migration extends BaseMigration
+{
+    public static function id()
+    {
+        return 'test-migration';
     }
 
-    /** @test */
-    public function testHandlerDoesntCallDifferentPluginMigrations()
+    /**
+     * @throws \Exception
+     */
+    public function up()
     {
-        $this->migration->expects($this->never())->method($this->anything());
+        throw new \Exception('up method called');
+    }
 
-        $handler = new Handler($this->worker, $this->logger);
-        $handler->add('another-key', $this->migration);
-        $handler->up('test');
+    /**
+     * @throws \Exception
+     */
+    public function down()
+    {
+        throw new \Exception('down method called');
     }
 }

--- a/tests/Unit/HandlerTest.php
+++ b/tests/Unit/HandlerTest.php
@@ -6,7 +6,6 @@ use CoenJacobs\Migrator\Handler;
 use CoenJacobs\Migrator\Contracts\Logger;
 use CoenJacobs\Migrator\Contracts\Worker;
 use CoenJacobs\Migrator\Contracts\Migration;
-use CoenJacobs\Migrator\Exceptions\ReservedNameException;
 use PHPUnit_Framework_TestCase;
 
 class HandlerTest extends PHPUnit_Framework_TestCase
@@ -68,32 +67,5 @@ class HandlerTest extends PHPUnit_Framework_TestCase
         $handler = new Handler($this->worker, $this->logger);
         $handler->add('another-key', $this->migration);
         $handler->up('test');
-    }
-
-    /** @test */
-    public function testHandlerDoesntAcceptMigrationsWithReservedName()
-    {
-        $this->expectException(ReservedNameException::class);
-
-        $handler = new Handler($this->worker, $this->logger);
-        $handler->add('core', $this->migration);
-    }
-
-    /** @test */
-    public function testHandlerDoesntUpMigrationsWithReservedName()
-    {
-        $this->expectException(ReservedNameException::class);
-
-        $handler = new Handler($this->worker, $this->logger);
-        $handler->up('core', $this->migration);
-    }
-
-    /** @test */
-    public function testHandlerDoesntDownMigrationsWithReservedName()
-    {
-        $this->expectException(ReservedNameException::class);
-
-        $handler = new Handler($this->worker, $this->logger);
-        $handler->down('core', $this->migration);
     }
 }


### PR DESCRIPTION
This also drops the need for 'core migrations', as the table that initially required it is now part of the `DatabaseLogger` and this specific migration is now being run outside of the flow for regular migrations. Thanks again for the great ideas @dannyvankooten! 🎉 

This allows plugins or vendors to create a specific migrations table for their own plugins, so the migrations are stored in _their own_ table, instead of all implementations in the _same_ table.